### PR TITLE
Suggested approach

### DIFF
--- a/EndlessClient/Rendering/Character/CharacterRendererUpdater.cs
+++ b/EndlessClient/Rendering/Character/CharacterRendererUpdater.cs
@@ -177,7 +177,7 @@ namespace EndlessClient.Rendering.Character
 
         private ICharacterRenderer InitializeRendererForCharacter(EOLib.Domain.Character.Character character)
         {
-            var renderer = _characterRendererFactory.CreateCharacterRenderer(character);
+            var renderer = _characterRendererFactory.CreateCharacterRenderer(character, isUiControl: false);
             renderer.Initialize();
             return renderer;
         }

--- a/EndlessClient/Rendering/Factories/CharacterRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/CharacterRendererFactory.cs
@@ -25,7 +25,6 @@ namespace EndlessClient.Rendering.Factories
         private readonly IRenderOffsetCalculator _renderOffsetCalculator;
         private readonly ICharacterPropertyRendererBuilder _characterPropertyRendererBuilder;
         private readonly ICharacterTextures _characterTextures;
-        private readonly IGameStateProvider _gameStateProvider;
         private readonly ICurrentMapProvider _currentMapProvider;
         private readonly IUserInputProvider _userInputProvider;
         private readonly IEffectRendererFactory _effectRendererFactory;
@@ -42,7 +41,6 @@ namespace EndlessClient.Rendering.Factories
                                         IRenderOffsetCalculator renderOffsetCalculator,
                                         ICharacterPropertyRendererBuilder characterPropertyRendererBuilder,
                                         ICharacterTextures characterTextures,
-                                        IGameStateProvider gameStateProvider,
                                         ICurrentMapProvider currentMapProvider,
                                         IUserInputProvider userInputProvider,
                                         IEffectRendererFactory effectRendererFactory,
@@ -59,7 +57,6 @@ namespace EndlessClient.Rendering.Factories
             _renderOffsetCalculator = renderOffsetCalculator;
             _characterPropertyRendererBuilder = characterPropertyRendererBuilder;
             _characterTextures = characterTextures;
-            _gameStateProvider = gameStateProvider;
             _currentMapProvider = currentMapProvider;
             _userInputProvider = userInputProvider;
             _effectRendererFactory = effectRendererFactory;
@@ -69,7 +66,7 @@ namespace EndlessClient.Rendering.Factories
             _clientWindowSizeRepository = clientWindowSizeRepository;
         }
 
-        public ICharacterRenderer CreateCharacterRenderer(EOLib.Domain.Character.Character character)
+        public ICharacterRenderer CreateCharacterRenderer(EOLib.Domain.Character.Character character, bool isUiControl)
         {
             return new CharacterRenderer(
                 (Game) _gameProvider.Game,
@@ -80,15 +77,15 @@ namespace EndlessClient.Rendering.Factories
                 _renderOffsetCalculator,
                 _characterPropertyRendererBuilder,
                 _characterTextures,
-                character,
-                _gameStateProvider,
                 _currentMapProvider,
                 _userInputProvider,
                 _effectRendererFactory,
                 _hatMetadataProvider,
                 _weaponMetadataProvider,
                 _sfxPlayer,
-                _clientWindowSizeRepository);
+                _clientWindowSizeRepository,
+                character,
+                isUiControl);
         }
     }
 }

--- a/EndlessClient/Rendering/Factories/ICharacterRendererFactory.cs
+++ b/EndlessClient/Rendering/Factories/ICharacterRendererFactory.cs
@@ -4,6 +4,6 @@ namespace EndlessClient.Rendering.Factories
 {
     public interface ICharacterRendererFactory
     {
-        ICharacterRenderer CreateCharacterRenderer(EOLib.Domain.Character.Character character);
+        ICharacterRenderer CreateCharacterRenderer(EOLib.Domain.Character.Character character, bool isUiControl);
     }
 }

--- a/EndlessClient/Test/CharacterStateTest.cs
+++ b/EndlessClient/Test/CharacterStateTest.cs
@@ -79,7 +79,7 @@ namespace EndlessClient.Test
             foreach (var displayState in _allDisplayStates)
             {
                 var props = GetRenderPropertiesForState(displayState);
-                _renderersForDifferentStates.Add(_characterRendererFactory.CreateCharacterRenderer(Character.Default.WithRenderProperties(props)));
+                _renderersForDifferentStates.Add(_characterRendererFactory.CreateCharacterRenderer(Character.Default.WithRenderProperties(props), isUiControl: false));
                 _renderersForDifferentStates.OfType<DrawableGameComponent>().Last().DrawOrder = 10;
             }
 

--- a/EndlessClient/UIControls/CharacterControl.cs
+++ b/EndlessClient/UIControls/CharacterControl.cs
@@ -23,7 +23,7 @@ namespace EndlessClient.UIControls
         public CharacterControl(Character character,
                                 ICharacterRendererFactory characterRendererFactory)
         {
-            _characterRenderer = characterRendererFactory.CreateCharacterRenderer(character);
+            _characterRenderer = characterRendererFactory.CreateCharacterRenderer(character, isUiControl: true);
         }
 
         public override void Initialize()


### PR DESCRIPTION
Instead of injecting `IGameStateProvider` and comparing the current game state against `PlayingTheGame` for in-game handling, construct the character renderer with a value indicating if it is a UI control or not.

A more elegant solution would probably be deriving a separate type for character renderers that are used pre-game and don't have all the in-game garbage associated with them. I'll probably take care of this in the future as part of rendering code cleanup. For now this should be good enough.